### PR TITLE
Return flows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 default:
-	python setup.py build_ext -b .
+	python2 setup.py build_ext -b .
 
 build:
 	cython -v -t --cplus pyemd/emd.pyx

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 default:
-	python2 setup.py build_ext -b .
+	python setup.py build_ext -b .
 
 build:
 	cython -v -t --cplus pyemd/emd.pyx

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,16 @@ API
   be symmetric and represent a metric.
 
 
+.. code:: python
+
+    emd, flows = emd_with_flows(first_signature, second_signature, distance_matrix)
+
+- ``first_signature``: A 1-dimensional numpy array of ``np.float``, of size N.
+- ``second_signature``: A 1-dimensional numpy array of ``np.float``, of size N.
+- ``distance_matrix``: A 2-dimensional array of ``np.float``, of size NxN. Must
+  be symmetric and represent a metric.
+
+
 Limitations and Caveats
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -69,9 +79,6 @@ Limitations and Caveats
   wrapper only instantiates the template with ``double`` (Cython converts
   ``np.float`` to ``double``). If there's demand, I can add support for other
   types.
-- The original C++ functions have an optional parameter ``F`` to
-  return the flow, which is not exposed by this wrapper. See the
-  documentation in ``pyemd/lib/emd_hat.hpp``.
 
 
 Contributing

--- a/pyemd/__init__.py
+++ b/pyemd/__init__.py
@@ -61,3 +61,4 @@ __license__ = 'MIT'
 __copyright__ = 'Copyright (c) 2016 Will Mayner'
 
 from .emd import emd
+from .emd import emd_with_flows

--- a/pyemd/emd.pyx
+++ b/pyemd/emd.pyx
@@ -3,6 +3,7 @@
 # distutils: language = c++
 
 from libcpp.vector cimport vector
+from libcpp.pair cimport pair
 import cython
 
 # Import both NumPy and the Cython declarations for NumPy
@@ -14,22 +15,57 @@ cimport numpy as np
 # ============================================
 
 cdef extern from "lib/emd_hat.hpp":
-    cdef double emd_hat_gd_metric_double(vector[double],
-                                         vector[double],
-                                         vector[vector[double]],
-                                         double,
-                                         vector[vector[double]]) except +
+    cdef pair[double, vector[vector[double]]] emd_hat_gd_metric_double_wrapper(vector[double],
+                                                 vector[double],
+                                                 vector[vector[double]],
+                                                 double) except +
+
 
 
 # Define the API
 # ==============
+def emd_with_flows(np.ndarray[np.float64_t, ndim=1, mode="c"] first_signature,
+                   np.ndarray[np.float64_t, ndim=1, mode="c"] second_signature,
+                   np.ndarray[np.float64_t, ndim=2, mode="c"] distance_matrix,
+                   extra_mass_penalty=-1):
+    """
+    Compute the Earth Mover's Distance between the given signature with the
+    given distance matrix.
+    Return a tuple containing the EMD value and the flows array.
+
+    :param first_signature: A 1D numpy array of ``np.double``, of length
+        :math:`N`.
+    :param second_signature: A 1D numpy array of ``np.double``, also of length
+        :math:`N`..
+    :param distance_matrix: A 2D numpy array of ``np.double``, of size
+        :math:`N \cross N`.
+    :param extra_mass_penalty: The penalty for extra mass. If you want the
+        resulting distance to be a metric, it should be at least half the
+        diameter of the space (maximum possible distance between any two
+        points). If you want partial matching you can set it to zero (but then
+        the resulting distance is not guaranteed to be a metric). The default
+        value is -1 which means the maximum value in the distance matrix is
+        used.
+    """
+    if (first_signature.shape[0] > distance_matrix.shape[0] or
+            second_signature.shape[0] > distance_matrix.shape[0]):
+        raise ValueError('Signature dimension cannot be larger than '
+                         'dimensions of distance matrix')
+
+    if (first_signature.shape[0] != second_signature.shape[0]):
+        raise ValueError("Signature dimensions must be equal")
+
+    return emd_hat_gd_metric_double_wrapper(first_signature,
+                                                 second_signature,
+                                                 distance_matrix,
+                                                 -1)
+
+
 
 def emd(np.ndarray[np.float64_t, ndim=1, mode="c"] first_signature,
         np.ndarray[np.float64_t, ndim=1, mode="c"] second_signature,
         np.ndarray[np.float64_t, ndim=2, mode="c"] distance_matrix,
-        extra_mass_penalty=-1,
-        np.ndarray[np.float64_t, ndim=2, mode="c"] flow_matrix
-        ):
+        extra_mass_penalty=-1):
     """
     Compute the Earth Mover's Distance between the given signatures with the
     given distance matrix.
@@ -47,18 +83,10 @@ def emd(np.ndarray[np.float64_t, ndim=1, mode="c"] first_signature,
         the resulting distance is not guaranteed to be a metric). The default
         value is -1 which means the maximum value in the distance matrix is
         used.
-    :param flow_matrix: The matrix of flows between the different bins.
     """
-    if (first_signature.shape[0] > distance_matrix.shape[0] or
-            second_signature.shape[0] > distance_matrix.shape[0]):
-        raise ValueError('Signature dimension cannot be larger than '
-                         'dimensions of distance matrix')
 
-    if (first_signature.shape[0] != second_signature.shape[0]):
-        raise ValueError("Signature dimensions must be equal")
-
-    return emd_hat_gd_metric_double(first_signature,
-                                    second_signature,
-                                    distance_matrix,
-                                    extra_mass_penalty,
-                                    flow_matrix)
+    emd,flows = emd_with_flows(first_signature,
+                               second_signature,
+                               distance_matrix,
+                               extra_mass_penalty)
+    return emd

--- a/pyemd/emd.pyx
+++ b/pyemd/emd.pyx
@@ -58,7 +58,7 @@ def emd_with_flows(np.ndarray[np.float64_t, ndim=1, mode="c"] first_signature,
     return emd_hat_gd_metric_double_wrapper(first_signature,
                                                  second_signature,
                                                  distance_matrix,
-                                                 -1)
+                                                 extra_mass_penalty)
 
 
 

--- a/pyemd/emd.pyx
+++ b/pyemd/emd.pyx
@@ -20,6 +20,11 @@ cdef extern from "lib/emd_hat.hpp":
                                                  vector[vector[double]],
                                                  double) except +
 
+    cdef vector[vector[double]] emd_hat_gd_metric_double_wrapper_vector(vector[double],
+                                                 vector[double],
+                                                 vector[vector[double]],
+                                                 double) except +
+
 
 
 # Define the API
@@ -27,7 +32,7 @@ cdef extern from "lib/emd_hat.hpp":
 def emd_with_flows(np.ndarray[np.float64_t, ndim=1, mode="c"] first_signature,
                    np.ndarray[np.float64_t, ndim=1, mode="c"] second_signature,
                    np.ndarray[np.float64_t, ndim=2, mode="c"] distance_matrix,
-                   extra_mass_penalty=-1):
+                   extra_mass_penalty=-1.0):
     """
     Compute the Earth Mover's Distance between the given signature with the
     given distance matrix.
@@ -56,16 +61,16 @@ def emd_with_flows(np.ndarray[np.float64_t, ndim=1, mode="c"] first_signature,
         raise ValueError("Signature dimensions must be equal")
 
     return emd_hat_gd_metric_double_wrapper(first_signature,
-                                                 second_signature,
-                                                 distance_matrix,
-                                                 extra_mass_penalty)
+                                            second_signature,
+                                            distance_matrix,
+                                            extra_mass_penalty)
 
 
 
 def emd(np.ndarray[np.float64_t, ndim=1, mode="c"] first_signature,
         np.ndarray[np.float64_t, ndim=1, mode="c"] second_signature,
         np.ndarray[np.float64_t, ndim=2, mode="c"] distance_matrix,
-        extra_mass_penalty=-1):
+        extra_mass_penalty=-1.0):
     """
     Compute the Earth Mover's Distance between the given signatures with the
     given distance matrix.

--- a/pyemd/emd.pyx
+++ b/pyemd/emd.pyx
@@ -17,7 +17,8 @@ cdef extern from "lib/emd_hat.hpp":
     cdef double emd_hat_gd_metric_double(vector[double],
                                          vector[double],
                                          vector[vector[double]],
-                                         double) except +
+                                         double,
+                                         vector[vector[double]]) except +
 
 
 # Define the API
@@ -26,7 +27,9 @@ cdef extern from "lib/emd_hat.hpp":
 def emd(np.ndarray[np.float64_t, ndim=1, mode="c"] first_signature,
         np.ndarray[np.float64_t, ndim=1, mode="c"] second_signature,
         np.ndarray[np.float64_t, ndim=2, mode="c"] distance_matrix,
-        extra_mass_penalty=-1):
+        extra_mass_penalty=-1,
+        np.ndarray[np.float64_t, ndim=2, mode="c"] flow_matrix
+        ):
     """
     Compute the Earth Mover's Distance between the given signatures with the
     given distance matrix.
@@ -44,6 +47,7 @@ def emd(np.ndarray[np.float64_t, ndim=1, mode="c"] first_signature,
         the resulting distance is not guaranteed to be a metric). The default
         value is -1 which means the maximum value in the distance matrix is
         used.
+    :param flow_matrix: The matrix of flows between the different bins.
     """
     if (first_signature.shape[0] > distance_matrix.shape[0] or
             second_signature.shape[0] > distance_matrix.shape[0]):
@@ -56,4 +60,5 @@ def emd(np.ndarray[np.float64_t, ndim=1, mode="c"] first_signature,
     return emd_hat_gd_metric_double(first_signature,
                                     second_signature,
                                     distance_matrix,
-                                    extra_mass_penalty)
+                                    extra_mass_penalty,
+                                    flow_matrix)

--- a/pyemd/lib/emd_hat.hpp
+++ b/pyemd/lib/emd_hat.hpp
@@ -82,11 +82,21 @@ emd_hat<long long int> emd_hat_long_long_int;
 std::pair< double, std::vector<std::vector<double>> > emd_hat_gd_metric_double_wrapper( const std::vector<double>& P,
                                                                           const std::vector<double>& Q,
                                                                           const std::vector<std::vector<double>>& C,
-                                                                          double extra_mass_penalty=-1) {
+                                                                          double extra_mass_penalty) {
     std::vector<std::vector<double>> flows(P.size(), std::vector<double>(P.size()));
     double emd = emd_hat_gd_metric_double(P, Q, C, extra_mass_penalty, &flows);
     auto results = std::make_pair(emd, flows);
     return results;
+}
+
+std::vector<std::vector<double>> emd_hat_gd_metric_double_wrapper_vector( const std::vector<double>& P,
+                                                                          const std::vector<double>& Q,
+                                                                          const std::vector<std::vector<double>>& C,
+                                                                          double extra_mass_penalty) {
+    std::vector<std::vector<double>> flows(P.size(), std::vector<double>(P.size()));
+    double emd = emd_hat_gd_metric_double(P, Q, C, extra_mass_penalty, &flows);
+    return flows;
+}
 /// =========================================================================
 
 

--- a/pyemd/lib/emd_hat.hpp
+++ b/pyemd/lib/emd_hat.hpp
@@ -1,6 +1,7 @@
 #ifndef EMD_HAT_HPP
 #define EMD_HAT_HPP
 
+#include <utility>
 #include <vector>
 #include "EMD_DEFS.hpp"
 #include "flow_utils.hpp"
@@ -38,7 +39,7 @@
 ///              to the extra mass bin.
 ///           Note that if F is the default NULL then FLOW_TYPE must be NO_FLOW.
 
-template<typename NUM_T, FLOW_TYPE_T FLOW_TYPE= NO_FLOW>
+template<typename NUM_T, FLOW_TYPE_T FLOW_TYPE= WITHOUT_EXTRA_MASS_FLOW>
 struct emd_hat_gd_metric {
     NUM_T operator()(const std::vector<NUM_T>& P, const std::vector<NUM_T>& Q,
                      const std::vector< std::vector<NUM_T> >& C,
@@ -70,6 +71,22 @@ emd_hat<int> emd_hat_int;
 emd_hat<double> emd_hat_double;
 emd_hat<long int> emd_hat_long_int;
 emd_hat<long long int> emd_hat_long_long_int;
+/// =========================================================================
+
+
+
+/// =========================================================================
+/// 25/11/2016 - Added by Rémi Louf <remi@sciti.es>
+/// -------------------------------------------------------------------------
+/// Wrapper function to output the flows
+std::pair< double, std::vector<std::vector<double>> > emd_hat_gd_metric_double_wrapper( const std::vector<double>& P,
+                                                                          const std::vector<double>& Q,
+                                                                          const std::vector<std::vector<double>>& C,
+                                                                          double extra_mass_penalty=-1) {
+    std::vector<std::vector<double>> flows(P.size(), std::vector<double>(P.size()));
+    double emd = emd_hat_gd_metric_double(P, Q, C, extra_mass_penalty, &flows);
+    auto results = std::make_pair(emd, flows);
+    return results;
 /// =========================================================================
 
 

--- a/pyemd/lib/emd_hat.hpp
+++ b/pyemd/lib/emd_hat.hpp
@@ -48,7 +48,7 @@ struct emd_hat_gd_metric {
 
 /// Same as emd_hat_gd_metric, but does not assume metric property for the ground distance (C).
 /// Note that C should still be symmetric and non-negative!
-template<typename NUM_T, FLOW_TYPE_T FLOW_TYPE= NO_FLOW>
+template<typename NUM_T, FLOW_TYPE_T FLOW_TYPE= WITHOUT_EXTRA_MASS_FLOW>
 struct emd_hat {
     NUM_T operator()(const std::vector<NUM_T>& P, const std::vector<NUM_T>& Q,
                      const std::vector< std::vector<NUM_T> >& C,

--- a/test/test_pyemd.py
+++ b/test/test_pyemd.py
@@ -2,9 +2,8 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-from pyemd import emd
+from pyemd import emd, emd_with_flows
 import pytest
-
 
 def test_case_1():
     first_signature = np.array([0.0, 1.0])
@@ -38,8 +37,24 @@ def test_larger_signatures():
     with pytest.raises(ValueError):
         emd(first_signature, second_signature, distance_matrix)
 
+def test_larger_signatures_flows():
+    first_signature = np.array([0.0, 1.0, 2.0])
+    second_signature = np.array([5.0, 3.0, 3.0])
+    distance_matrix = np.array([[0.0, 0.5],
+                                [0.5, 0.0]])
+    with pytest.raises(ValueError):
+        emd_flows(first_signature, second_signature, distance_matrix)
+
 
 def test_larger_signatures_1():
+    first_signature = np.array([0.0, 1.0, 2.0])
+    second_signature = np.array([5.0, 3.0])
+    distance_matrix = np.array([[0.0, 0.5],
+                                [0.5, 0.0]])
+    with pytest.raises(ValueError):
+        emd_flows(first_signature, second_signature, distance_matrix)
+
+def test_larger_signatures_1_flows():
     first_signature = np.array([0.0, 1.0, 2.0])
     second_signature = np.array([5.0, 3.0])
     distance_matrix = np.array([[0.0, 0.5],
@@ -56,6 +71,14 @@ def test_larger_signatures_2():
     with pytest.raises(ValueError):
         emd(first_signature, second_signature, distance_matrix)
 
+def test_larger_signatures_2_flows():
+    first_signature = np.array([0.0, 1.0])
+    second_signature = np.array([5.0, 3.0, 3.0])
+    distance_matrix = np.array([[0.0, 0.5],
+                                [0.5, 0.0]])
+    with pytest.raises(ValueError):
+        emd_flows(first_signature, second_signature, distance_matrix)
+
 
 def test_different_signature_dims():
     first_signature = np.array([0.0, 1.0])
@@ -66,6 +89,14 @@ def test_different_signature_dims():
     with pytest.raises(ValueError):
         emd(first_signature, second_signature, distance_matrix)
 
+def test_different_signature_dims_flows():
+    first_signature = np.array([0.0, 1.0])
+    second_signature = np.array([5.0, 3.0, 3.0])
+    distance_matrix = np.array([[0.0, 0.5, 0.0],
+                                [0.5, 0.0, 0.0],
+                                [0.5, 0.0, 0.0]])
+    with pytest.raises(ValueError):
+        emd_flows(first_signature, second_signature, distance_matrix)
 
 def test_symmetric_distance_matrix():
     first_signature = np.array([0.0, 1.0])
@@ -74,3 +105,11 @@ def test_symmetric_distance_matrix():
                                 [0.5, 0.0]])
     with pytest.raises(ValueError):
         emd(first_signature, second_signature, distance_matrix)
+
+def test_symmetric_distance_matrix_flows():
+    first_signature = np.array([0.0, 1.0])
+    second_signature = np.array([5.0, 3.0])
+    distance_matrix = np.array([[0.0, 0.5, 3.0],
+                                [0.5, 0.0]])
+    with pytest.raises(ValueError):
+        emd_flows(first_signature, second_signature, distance_matrix)


### PR DESCRIPTION
I added a wrapper in the C++ code that initialises the flows, and returns them along with the EMD value. 
I did not break the existing API, and just added a emd_with_flows function that returns both the value and the flows.

Tested on a previous version of PyEMD. Weirdly, I get crazy errors when I compile with this version, but I don't think it is due to my changes. 