### PR TITLE
Include LICENSE and data files via MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,9 @@
-include pyemd/emd.cpp
+graft pyemd
+graft test
+
+include README.rst
+include LICENSE
+include conftest.py
+
+global-exclude __pycache__ *.py[cod]
+global-exclude *.so *.dylib

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,6 @@ setup(
     url=about['__url__'],
     license=about['__license__'],
     packages=['pyemd'],
-    package_data={'pyemd': ['emd.pyx', 'lib/*.hpp', '../README.rst']},
     install_requires=requires,
     cmdclass=cmdclass,
     setup_requires=requires,


### PR DESCRIPTION
This includes files required for compilation and distribution via
MANIFEST.in rather than package_data which gets installed.

---

**Before** this change, this is the content of the source distribution file:

```
x pyemd-0.4.2/
x pyemd-0.4.2/PKG-INFO
x pyemd-0.4.2/pyemd/
x pyemd-0.4.2/pyemd/__about__.py
x pyemd-0.4.2/pyemd/__init__.py
x pyemd-0.4.2/pyemd/emd.cpp
x pyemd-0.4.2/pyemd/emd.pyx
x pyemd-0.4.2/pyemd/lib/
x pyemd-0.4.2/pyemd/lib/EMD_DEFS.hpp
x pyemd-0.4.2/pyemd/lib/emd_hat.hpp
x pyemd-0.4.2/pyemd/lib/emd_hat_impl.hpp
x pyemd-0.4.2/pyemd/lib/emd_hat_signatures_interface.hpp
x pyemd-0.4.2/pyemd/lib/flow_utils.hpp
x pyemd-0.4.2/pyemd/lib/min_cost_flow.hpp
x pyemd-0.4.2/README.rst
x pyemd-0.4.2/setup.py
x pyemd-0.4.2/test/
x pyemd-0.4.2/test/test_pyemd.py
```

And the files to be installed:

```
build/lib.macosx-10.6-x86_64-3.5
build/lib.macosx-10.6-x86_64-3.5/pyemd
build/lib.macosx-10.6-x86_64-3.5/pyemd/__about__.py
build/lib.macosx-10.6-x86_64-3.5/pyemd/__init__.py
build/lib.macosx-10.6-x86_64-3.5/pyemd/emd.cpython-35m-darwin.so
build/lib.macosx-10.6-x86_64-3.5/pyemd/emd.pyx
build/lib.macosx-10.6-x86_64-3.5/pyemd/lib
build/lib.macosx-10.6-x86_64-3.5/pyemd/lib/EMD_DEFS.hpp
build/lib.macosx-10.6-x86_64-3.5/pyemd/lib/emd_hat.hpp
build/lib.macosx-10.6-x86_64-3.5/pyemd/lib/emd_hat_impl.hpp
build/lib.macosx-10.6-x86_64-3.5/pyemd/lib/emd_hat_signatures_interface.hpp
build/lib.macosx-10.6-x86_64-3.5/pyemd/lib/flow_utils.hpp
build/lib.macosx-10.6-x86_64-3.5/pyemd/lib/min_cost_flow.hpp
build/lib.macosx-10.6-x86_64-3.5/README.rst
```

**After** this change, this is the source distribution content:

```
x pyemd-0.4.2/
x pyemd-0.4.2/conftest.py
x pyemd-0.4.2/LICENSE
x pyemd-0.4.2/PKG-INFO
x pyemd-0.4.2/pyemd/
x pyemd-0.4.2/pyemd/__about__.py
x pyemd-0.4.2/pyemd/__init__.py
x pyemd-0.4.2/pyemd/emd.cpp
x pyemd-0.4.2/pyemd/emd.pyx
x pyemd-0.4.2/pyemd/lib/
x pyemd-0.4.2/pyemd/lib/EMD_DEFS.hpp
x pyemd-0.4.2/pyemd/lib/emd_hat.hpp
x pyemd-0.4.2/pyemd/lib/emd_hat_impl.hpp
x pyemd-0.4.2/pyemd/lib/emd_hat_signatures_interface.hpp
x pyemd-0.4.2/pyemd/lib/flow_utils.hpp
x pyemd-0.4.2/pyemd/lib/min_cost_flow.hpp
x pyemd-0.4.2/README.rst
x pyemd-0.4.2/setup.py
x pyemd-0.4.2/test/
x pyemd-0.4.2/test/test_pyemd.py
```

And the files to be installed:
```
build/lib.macosx-10.6-x86_64-3.5
build/lib.macosx-10.6-x86_64-3.5/pyemd
build/lib.macosx-10.6-x86_64-3.5/pyemd/__about__.py
build/lib.macosx-10.6-x86_64-3.5/pyemd/__init__.py
build/lib.macosx-10.6-x86_64-3.5/pyemd/emd.cpython-35m-darwin.so
```

Unless the `.pyx` and `.hpp` files are intended for final user's usage, then the latter result is the correct one.