### PR TITLE
Don't easy_install latest numpy if numpy is already available.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,9 +92,24 @@ with open('./pyemd/__about__.py') as f:
     exec(f.read(), ABOUT)
 
 
-REQUIRES = [
-    'numpy >=1.9.0, <2.0.0'
-]
+NUMPY_REQUIREMENT = ['numpy >=1.9.0, <2.0.0']
+
+# Copied from scipy's installer, to solve the same issues they saw:
+
+# Figure out whether to add ``*_requires = ['numpy']``.
+# We don't want to do that unconditionally, because we risk updating
+# an installed numpy which fails too often.  Just if it's not installed, we
+# may give it a try.  See scipy gh-3379.
+try:
+    import numpy
+except ImportError:  # We do not have numpy installed
+    REQUIRES = NUMPY_REQUIREMENT
+else:
+    # If we're building a wheel, assume there already exist numpy wheels
+    # for this platform, so it is safe to add numpy to build requirements.
+    # See scipy gh-5184.
+    REQUIRES = (NUMPY_REQUIREMENT if 'bdist_wheel' in sys.argv[1:]
+                      else [])
 
 setup(
     name=ABOUT['__title__'],


### PR DESCRIPTION
If you pip install this requirements file (into an empty virtual env, tested on a base ubuntu docker container):
```
numpy==1.15.1  # Not the latest numpy
pyemd==0.5.1
```

Then the `setup_requires` dependency on numpy will cause an _easy_install_ of the latest numpy (1.16.2) and build against that, despite numpy being in the requirements file and already installed.

This problem has bitten other projects that build C/C++/Cython dependencies against numpy, including scipy. Following the issues and related threads on scipy, it appears than setuptools is not going to fix the breaking easy_installs anytime soon, so I directly copied their pattern of checking for numpy before adding it to the setup_requirement.
