### PR TITLE
Change numpy requirement to <1.20.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ with open('./pyemd/__about__.py') as f:
     exec(f.read(), ABOUT)
 
 
-NUMPY_REQUIREMENT = ['numpy >=1.9.0, <2.0.0']
+NUMPY_REQUIREMENT = ['numpy >=1.9.0, <1.20.0']
 
 # Copied from scipy's installer, to solve the same issues they saw:
 


### PR DESCRIPTION
Numpy dropped support for python 3.6 in 1.20.0. https://github.com/numpy/numpy/releases/tag/v1.20.0. 

The setup.py file in this package indicates support for python 3.6. This is causing some issues when trying to run setup.py in another project.