### PR TITLE
Fix numpy requirement (<1.20.0) for Python <= 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,5 +155,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,10 @@ with open('./pyemd/__about__.py') as f:
     exec(f.read(), ABOUT)
 
 
-NUMPY_REQUIREMENT = ['numpy >=1.9.0, <2.0.0']
+NUMPY_REQUIREMENT = [
+    "numpy >=1.9.0, <1.20.0; python_version<='3.6'"
+    "numpy >=1.9.0, <2.0.0; python_version>'3.6'"
+]
 
 # Copied from scipy's installer, to solve the same issues they saw:
 
@@ -150,5 +153,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )


### PR DESCRIPTION
- numpy >= 1.20 isnt supported for python <= 3.6. 
- This updates `setup_requires` in `setup.py` to prevent the wrong numpy being installed.

Additional changes removed as discussed in #50 (which this duplicates).