### PR TITLE
Unconditionally require numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,26 +109,10 @@ with open('./pyemd/__about__.py') as f:
     exec(f.read(), ABOUT)
 
 
-NUMPY_REQUIREMENT = [
+REQUIRES = [
     "numpy >=1.9.0, <1.20.0; python_version<='3.6'",
     "numpy >=1.9.0, <2.0.0; python_version>'3.6'"
 ]
-
-# Copied from scipy's installer, to solve the same issues they saw:
-
-# Figure out whether to add ``*_requires = ['numpy']``.
-# We don't want to do that unconditionally, because we risk updating
-# an installed numpy which fails too often.  Just if it's not installed, we
-# may give it a try.  See scipy gh-3379.
-try:
-    import numpy
-except ImportError:  # We do not have numpy installed
-    REQUIRES = NUMPY_REQUIREMENT
-else:
-    # If we're building a wheel, assume there already exist numpy wheels
-    # for this platform, so it is safe to add numpy to build requirements.
-    # See scipy gh-5184.
-    REQUIRES = (NUMPY_REQUIREMENT if 'bdist_wheel' in sys.argv[1:] else [])
 
 setup(
     name=ABOUT['__title__'],


### PR DESCRIPTION
Not requiring it when it is already installed breaks Debian package builds,
which use setup.py install and translate requires to Debian package Depends.

SciPy has reverted back to unconditionally requiring numpy too.

CC: @TimothyFitz
Fixes: https://bugs.debian.org/1030653
See-also: https://github.com/scipy/scipy/issues/12727
See-also: https://github.com/scipy/scipy/pull/12729
See-also: scipy commit 988d69724c8ee963e45f8fedf9cba1ca18bf941d
Reverts: https://github.com/wmayner/pyemd/pull/38
Reverts: commit b0dde3b6d0a614cc1452093959a5fd65590b4d74
